### PR TITLE
Introduce AttributeRef to model paths

### DIFF
--- a/modules/core/src/main/scala/lo/codec.scala
+++ b/modules/core/src/main/scala/lo/codec.scala
@@ -26,7 +26,7 @@ import io.circe.{Decoder, Encoder}
 
 import scodec.bits.ByteVector
 
-import dynosaur.model.{AttributeName, AttributeValue}
+import dynosaur.model.{AttributeName, AttributeRef, AttributeValue}
 import model._
 
 object codec {
@@ -77,6 +77,12 @@ object codec {
 
   implicit val attributeNameDecoder: Decoder[AttributeName] =
     Decoder.decodeString.map(AttributeName.apply)
+
+  implicit val attributeRefEncoder: Encoder[AttributeRef] =
+    Encoder.encodeNonEmptyList[AttributeName].contramap(_.path)
+
+  implicit val attributeRefDecoder: Decoder[AttributeRef] =
+    Decoder.decodeNonEmptyList[AttributeName].map(AttributeRef.apply)
 
   implicit val expressionPlaceholderEncoder: Encoder[ExpressionPlaceholder] =
     Encoder.encodeString.contramap(_.value)

--- a/modules/core/src/main/scala/lo/model.scala
+++ b/modules/core/src/main/scala/lo/model.scala
@@ -18,7 +18,7 @@ package dynosaur
 package lo
 package model
 
-import dynosaur.model.{AttributeName, AttributeValue}
+import dynosaur.model.{AttributeRef, AttributeValue}
 
 import cats.implicits._
 import scala.reflect.macros.whitebox
@@ -137,7 +137,7 @@ case class PutItemRequest(
     tableName: TableName,
     item: AttributeValue.M,
     conditionExpression: Option[ConditionExpression] = None,
-    expressionAttributeNames: Map[ExpressionAlias, AttributeName] = Map.empty,
+    expressionAttributeNames: Map[ExpressionAlias, AttributeRef] = Map.empty,
     expressionAttributeValues: Map[ExpressionPlaceholder, AttributeValue] =
       Map.empty,
     returnValues: ReturnValues = ReturnValues.None
@@ -150,7 +150,7 @@ case class GetItemRequest(
     key: AttributeValue.M,
     consistent: Boolean = false,
     projectionExpression: Option[ProjectionExpression] = None,
-    expressionAttributeNames: Map[ExpressionAlias, AttributeName] = Map.empty
+    expressionAttributeNames: Map[ExpressionAlias, AttributeRef] = Map.empty
 )
 
 case class GetItemResponse(
@@ -161,7 +161,7 @@ case class DeleteItemRequest(
     tableName: TableName,
     key: AttributeValue.M,
     conditionExpression: Option[ConditionExpression] = None,
-    expressionAttributeNames: Map[ExpressionAlias, AttributeName] = Map.empty,
+    expressionAttributeNames: Map[ExpressionAlias, AttributeRef] = Map.empty,
     expressionAttributeValues: Map[ExpressionPlaceholder, AttributeValue] =
       Map.empty,
     returnValues: ReturnValues = ReturnValues.None
@@ -175,7 +175,7 @@ case class UpdateItemRequest(
     tableName: TableName,
     key: AttributeValue.M,
     updateExpression: UpdateExpression,
-    expressionAttributeNames: Map[ExpressionAlias, AttributeName] = Map.empty,
+    expressionAttributeNames: Map[ExpressionAlias, AttributeRef] = Map.empty,
     expressionAttributeValues: Map[ExpressionPlaceholder, AttributeValue] =
       Map.empty,
     conditionExpression: Option[ConditionExpression] = None,

--- a/modules/core/src/main/scala/model/AttributeValue.scala
+++ b/modules/core/src/main/scala/model/AttributeValue.scala
@@ -17,7 +17,7 @@
 package dynosaur
 package model
 
-import cats._, implicits._
+import cats._, implicits._, data._
 import scodec.bits.ByteVector
 
 /**
@@ -31,6 +31,8 @@ import scodec.bits.ByteVector
   * 3) Add a zipper, possibly reusing the one from circe, to get errors
   */
 case class AttributeName(value: String)
+
+case class AttributeRef(path: NonEmptyList[AttributeName])
 
 sealed trait AttributeValue {
   def `null`: Option[AttributeValue.NULL.type] = this match {


### PR DESCRIPTION
Introduce the `AttributeRef` case class to model the attribute path.

When serialising an object (`AttributeValue.M`) the keys are modelled as `AttributeName`

```json
"Item": {
  "a": {
    "M": {
      "b": {
        "S": "foo"
      }
    }
  }
}
```

Both `a` and `b` are valid `AttributeName`. However, both in the expressions (Condition, Projection and Filter) and aliasing we need to reference path, and the `AttributeName` is not enough anymore. 

The path separation in `AttributeName` means something different than nested fields but it means that the key itself contain the `.` (Dot).

So we need another thing to reference a path. This PR introduces the `AttributeRef` to model a path. It is literally a non-empty list of `AttributeName`.